### PR TITLE
Add first person offset

### DIFF
--- a/CameraPlus/CameraPlusBehaviour.cs
+++ b/CameraPlus/CameraPlusBehaviour.cs
@@ -56,6 +56,7 @@ namespace CameraPlus
         protected bool _thirdPerson;
         public Vector3 ThirdPersonPos;
         public Vector3 ThirdPersonRot;
+        public Vector3 FirstPersonOffset;
         public Config Config;
 
         protected RenderTexture _camRenderTexture;
@@ -197,6 +198,8 @@ namespace CameraPlus
 
             Plugin.Instance.ActiveSceneChanged += SceneManager_activeSceneChanged;
 
+            FirstPersonOffset = Config.FirstPersonPositionOffset;
+
             SceneManager_activeSceneChanged(new Scene(), new Scene());
             Plugin.Log($"Camera \"{Path.GetFileName(Config.FilePath)} successfully initialized!\"");
         }
@@ -234,11 +237,13 @@ namespace CameraPlus
             {
                 transform.position = _mainCamera.transform.position;
                 transform.rotation = _mainCamera.transform.rotation;
+
             }
             else
             {
                 ThirdPersonPos = Config.Position;
                 ThirdPersonRot = Config.Rotation;
+                FirstPersonOffset = Config.FirstPersonPositionOffset;
             }
             
             CreateScreenRenderTexture();
@@ -339,6 +344,7 @@ namespace CameraPlus
                     {
                         transform.position = _mainCamera.transform.position;
                         transform.rotation = _mainCamera.transform.rotation;
+                        FirstPersonOffset = Config.FirstPersonPositionOffset;
                     }
                     else
                     {
@@ -368,7 +374,7 @@ namespace CameraPlus
                     return;
                 }
 
-                transform.position = Vector3.Lerp(transform.position, camera.position,
+                transform.position = Vector3.Lerp(transform.position, camera.position + FirstPersonOffset,
                     Config.positionSmooth * Time.unscaledDeltaTime);
 
                 transform.rotation = Quaternion.Slerp(transform.rotation, camera.rotation,
@@ -695,6 +701,7 @@ namespace CameraPlus
                 ThirdPerson = Config.thirdPerson;
                 ThirdPersonPos = Config.Position;
                 ThirdPersonRot = Config.Rotation;
+                FirstPersonOffset = Config.FirstPersonPositionOffset;
                 CreateScreenRenderTexture();
                 CloseContextMenu();
                 Config.Save();
@@ -715,8 +722,10 @@ namespace CameraPlus
                 {
                     Config.Position = Config.DefaultPosition;
                     Config.Rotation = Config.DefaultRotation;
+                    Config.FirstPersonPositionOffset = Config.DefaultFirstPersonPositionOffset;
                     ThirdPersonPos = Config.DefaultPosition;
                     ThirdPersonRot = Config.DefaultRotation;
+                    FirstPersonOffset = Config.FirstPersonPositionOffset;
                     Config.Save();
                     CloseContextMenu();
                 });

--- a/CameraPlus/CameraUtilities.cs
+++ b/CameraPlus/CameraUtilities.cs
@@ -51,6 +51,7 @@ namespace CameraPlus
                 
                 config.Position = config.DefaultPosition;
                 config.Rotation = config.DefaultRotation;
+                config.FirstPersonPositionOffset = config.DefaultFirstPersonPositionOffset;
                 config.Save();
                 Plugin.Log($"Success creating new camera \"{cameraName}\"");
             }

--- a/CameraPlus/Config.cs
+++ b/CameraPlus/Config.cs
@@ -24,6 +24,10 @@ namespace CameraPlus
         public float angy;
         public float angz;
 
+        public float firstPersonPosOffsetX;
+        public float firstPersonPosOffsetY;
+        public float firstPersonPosOffsetZ;
+
         public int screenWidth = Screen.width;
         public int screenHeight = Screen.height;
         public int screenPosX;
@@ -98,6 +102,28 @@ namespace CameraPlus
             get
             {
                 return new Vector3(15f, 0f, 0f);
+            }
+        }
+
+        public Vector3 FirstPersonPositionOffset
+        {
+            get
+            {
+                return new Vector3(firstPersonPosOffsetX, firstPersonPosOffsetY, firstPersonPosOffsetZ);
+            }
+            set
+            {
+                firstPersonPosOffsetX = value.x;
+                firstPersonPosOffsetY = value.y;
+                firstPersonPosOffsetZ = value.z;
+            }
+        }
+
+        public Vector3 DefaultFirstPersonPositionOffset
+        {
+            get
+            {
+                return new Vector3(0, 0, 0);
             }
         }
 


### PR DESCRIPTION
The bulk of the code was done by @megalon, I just cherry-picked the relevant commits and fixed some merge conflicts.

This adds an offset for the first person camera to create an effect similar to that used in Beat Saber trailers.